### PR TITLE
Move to extension registration

### DIFF
--- a/WebChat.php
+++ b/WebChat.php
@@ -1,69 +1,12 @@
 <?php
-/**
- * WebChat
- *
- * Integrates a web chat client in to a special page, for example Mibbit.
- *
- * @file
- * @ingroup Extensions
- *
- * @link http://www.mediawiki.org/wiki/Extension:WebChat
- *
- * @author Robert Leverington <robert@rhl.me.uk>
- * @copyright Copyright © 2008 - 2009 Robert Leverington.
- * @copyright Copyright © 2009 Marco 27.
- * @license http://www.gnu.org/copyleft/gpl.html GNU General Public License 2.0 or later
- */
-
-// If this is run directly from the web die as this is not a valid entry point.
-if ( !defined( 'MEDIAWIKI' ) ) { die( 'Invalid entry point.' );
+if ( function_exists( 'wfLoadExtension' ) ) {
+	wfLoadExtension( 'WebChat' );
+	wfWarn(
+		'Deprecated PHP entry point used for WebChat extension. ' .
+		'Please use wfLoadExtension instead, ' .
+		'see https://www.mediawiki.org/wiki/Extension_registration for more details.'
+	);
+	return;
+} else {
+	die( 'This version of the FooBar extension requires MediaWiki 1.25+' );
 }
-
-// Extension credits.
-$wgExtensionCredits[ 'specialpage' ][] = [
-	'path'           => __FILE__,
-	'name'           => 'WebChat',
-	'descriptionmsg' => 'webchat-desc',
-	'author'         => [ 'Robert Leverington', 'Marco 27' ],
-	'url'            => 'https://www.mediawiki.org/wiki/Extension:WebChat',
-	'version'        => '1.3.0',
-];
-
-$dir = __DIR__ . '/';
-
-// Register special page.
-$wgSpecialPages['WebChat'] = 'WebChat';
-$wgAutoloadClasses['WebChat'] = $dir . 'WebChat_body.php';
-
-// Extension messages.
-$wgMessagesDirs['WebChat'] = __DIR__ . '/i18n';
-$wgExtensionMessagesFiles['WebChatAlias'] =  $dir . 'WebChat.alias.php';
-
-// Default configuration.
-$wgWebChatServer  = '';
-$wgWebChatChannel = '';
-$wgWebChatClient  = '';
-$wgWebChatClients = [
-	'Mibbit' => [
-		'url' => 'http://embed.mibbit.com/index.html',
-		'parameters' => [
-			'noServerMotd' => 'true',
-			'server'  => '$$$server$$$',
-			'channel' => '$$$channel$$$',
-			'nick'    => '$$$nick$$$',
-		],
-	],
-	'freenodeChat' => [
-		'url' => '//webchat.freenode.net/',
-		'parameters' => [
-			'channels' => '$$$channel$$$',
-			'nick'    => '$$$nick$$$',
-		],
-	]
-];
-
-// Default permissions.
-$wgAvailableRights[] = 'webchat';
-$wgGroupPermissions['*'    ]['webchat'] = false;
-$wgGroupPermissions['user' ]['webchat'] = true;
-$wgGroupPermissions['sysop']['webchat'] = true;

--- a/extension.json
+++ b/extension.json
@@ -1,0 +1,63 @@
+{
+	"name": "WebChat",
+	"version": "1.3.0",
+	"author": [
+		"Robert Leverington",
+		"Marco 27"
+	],
+	"url": "https://www.mediawiki.org/wiki/Extension:WebChat",
+	"descriptionmsg": "webchat-desc",
+	"type": "specialpage",
+	"GroupPermissions": {
+		"*": {
+			"webchat": false
+		},
+		"user": {
+			"webchat": true
+		},
+		"sysop": {
+			"webchat": true
+		}
+	},
+	"AvailableRights": [
+		"webchat"
+	],
+	"SpecialPages": {
+		"WebChat": "WebChat"
+	},
+	"MessagesDirs": {
+		"WebChat": [
+			"i18n"
+		]
+	},
+	"ExtensionMessagesFiles": {
+		"WebChatAlias": "WebChat.alias.php"
+	},
+	"AutoloadClasses": {
+		"WebChat": "WebChat_body.php"
+	},
+	"config": {
+		"WebChatServer": "",
+		"WebChatChannel": "",
+		"WebChatClient": "",
+		"WebChatClients": {
+			"Mibbit": {
+				"url": "http://embed.mibbit.com/index.html",
+				"parameters": {
+					"noServerMotd": "true",
+					"server": "$$$server$$$",
+					"channel": "$$$channel$$$",
+					"nick": "$$$nick$$$"
+				}
+			},
+			"freenodeChat": {
+				"url": "//webchat.freenode.net/",
+				"parameters": {
+					"channels": "$$$channel$$$",
+					"nick": "$$$nick$$$"
+				}
+			}
+		}
+	},
+	"manifest_version": 1
+}


### PR DESCRIPTION
The automated script (maintenance/convertExtensionToRegistration.ph) for converting to extension registration seems to have worked just fine, so thought I'd submit a pull request.

I also deprecated using the old .php entry-point. This breaks the extension for MW versions below 1.25, but the extension page already states it only works for MW 1.25+, so that shouldn't matter.
