### PR TITLE
Use full height of window

### DIFF
--- a/WebChat_body.php
+++ b/WebChat_body.php
@@ -53,7 +53,7 @@ class WebChat extends SpecialPage {
 '/* <![CDATA[ */
 function webChatExpand( elem ) {
 	height = elem.height;
-	elem.height = screen.height - 500;
+	elem.height = window.innerHeight;
 }
 /* ]]> */'
 			) );


### PR DESCRIPTION
Pretty much the one thing that annoyed me when I first installed this extension a couple years ago is that the IRC window doesn't use the full height of the browser window it is in.

At the time, I patched it locally, and didn't consider submitting a patch to the extension itself. Since I was already looking at the extension for PR #1, and noticed the height issue since I overwrote my local version, I thought I might as well submit it.

Tl;dr: The IRC window is now as large as the visible browser area (minus any toolbars and so on), rather than 500 pixels shorter than the whole screen.
